### PR TITLE
Feature/cc 184/dev pub sync performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "php": ">=7.1",
     "php-amqplib/php-amqplib": "^2.6",
     "spryker/kernel": "^3.20.0",
-    "spryker/queue": "^1.1.0",
-    "spryker/store": "^1.6.0",
+    "spryker/queue": "^1.1.2",
+    "spryker/store": "^1.9.0",
     "spryker/transfer": "^3.6.0"
   },
   "require-dev": {

--- a/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientBridge.php
+++ b/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientBridge.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Client\RabbitMq\Dependency\Client;
 
+use Generated\Shared\Transfer\StoreTransfer;
+
 class RabbitMqToStoreClientBridge implements RabbitMqToStoreClientInterface
 {
     /**
@@ -28,5 +30,15 @@ class RabbitMqToStoreClientBridge implements RabbitMqToStoreClientInterface
     public function getCurrentStore()
     {
         return $this->storeClient->getCurrentStore();
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Generated\Shared\Transfer\StoreTransfer
+     */
+    public function getStoreByName(string $name): StoreTransfer
+    {
+        return $this->storeClient->getStoreByName($name);
     }
 }

--- a/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientInterface.php
+++ b/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientInterface.php
@@ -7,10 +7,19 @@
 
 namespace Spryker\Client\RabbitMq\Dependency\Client;
 
+use Generated\Shared\Transfer\StoreTransfer;
+
 interface RabbitMqToStoreClientInterface
 {
     /**
      * @return \Generated\Shared\Transfer\StoreTransfer
      */
     public function getCurrentStore();
+
+    /**
+     * @param string $name
+     *
+     * @return \Generated\Shared\Transfer\StoreTransfer
+     */
+    public function getStoreByName(string $name): StoreTransfer;
 }

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManager.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManager.php
@@ -31,12 +31,12 @@ class ConnectionManager implements ConnectionManagerInterface
     /**
      * @var array|null Keys are pool names, values are lists of channels.
      */
-    protected $channelMapByPoolName;
+    protected $connectionMapByPoolName;
 
     /**
      * @var array|null Keys are store names, values are lists of channels.
      */
-    protected $channelMapByStoreName;
+    protected $connectionMapByStoreName;
 
     /**
      * @var string|null
@@ -63,11 +63,11 @@ class ConnectionManager implements ConnectionManagerInterface
      */
     protected function getConnectionMapByPoolName()
     {
-        if ($this->channelMapByPoolName === null) {
-            $this->channelMapByPoolName = $this->mapConnectionsByPoolName($this->storeClient->getCurrentStore()->getQueuePools());
+        if ($this->connectionMapByPoolName === null) {
+            $this->connectionMapByPoolName = $this->mapConnectionsByPoolName($this->storeClient->getCurrentStore()->getQueuePools());
         }
 
-        return $this->channelMapByPoolName;
+        return $this->connectionMapByPoolName;
     }
 
     /**
@@ -75,11 +75,11 @@ class ConnectionManager implements ConnectionManagerInterface
      */
     protected function getConnectionMapByStoreName()
     {
-        if ($this->channelMapByStoreName === null) {
-            $this->channelMapByStoreName = $this->mapConnectionsByStoreName();
+        if ($this->connectionMapByStoreName === null) {
+            $this->connectionMapByStoreName = $this->mapConnectionsByStoreName();
         }
 
-        return $this->channelMapByStoreName;
+        return $this->connectionMapByStoreName;
     }
 
     /**
@@ -87,15 +87,15 @@ class ConnectionManager implements ConnectionManagerInterface
      */
     protected function mapConnectionsByStoreName()
     {
-        $channelMap = [];
+        $connectionMap = [];
         foreach ($this->connectionMap as $connection) {
             foreach ($connection->getStoreNames() as $storeName) {
                 $uniqueChannelId = $this->getUniqueChannelId($connection);
-                $channelMap[$storeName][$uniqueChannelId] = $connection;
+                $connectionMap[$storeName][$uniqueChannelId] = $connection;
             }
         }
 
-        return $channelMap;
+        return $connectionMap;
     }
 
     /**
@@ -105,12 +105,12 @@ class ConnectionManager implements ConnectionManagerInterface
      */
     protected function mapConnectionsByPoolName(array $queuePools)
     {
-        $channelMap = [];
+        $connectionMap = [];
         foreach ($queuePools as $queuePoolName => $connectionNames) {
-            $channelMap[$queuePoolName] = $this->getConnectionByName($connectionNames);
+            $connectionMap[$queuePoolName] = $this->getConnectionByName($connectionNames);
         }
 
-        return $channelMap;
+        return $connectionMap;
     }
 
     /**

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManager.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManager.php
@@ -29,12 +29,12 @@ class ConnectionManager implements ConnectionManagerInterface
     protected $connectionMap;
 
     /**
-     * @var array|null Keys are pool names, values are lists of channels.
+     * @var array|null Keys are pool names, values are lists of connections.
      */
     protected $connectionMapByPoolName;
 
     /**
-     * @var array|null Keys are store names, values are lists of channels.
+     * @var array|null Keys are store names, values are lists of connections.
      */
     protected $connectionMapByStoreName;
 
@@ -120,13 +120,13 @@ class ConnectionManager implements ConnectionManagerInterface
      */
     protected function getConnectionByName(array $connectionNames)
     {
-        $channels = [];
+        $connections = [];
         foreach ($connectionNames as $connectionName) {
             $uniqueChannelId = $this->getUniqueChannelId($this->getConnectionMap()[$connectionName]);
-            $channels[$uniqueChannelId] = $this->getConnectionMap()[$connectionName];
+            $connections[$uniqueChannelId] = $this->getConnectionMap()[$connectionName];
         }
 
-        return $channels;
+        return $connections;
     }
 
     /**

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManagerInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManagerInterface.php
@@ -11,17 +11,19 @@ interface ConnectionManagerInterface
 {
     /**
      * @param string $queuePoolName
+     * @param string|null $locale
      *
      * @return \PhpAmqpLib\Channel\AMQPChannel[]
      */
-    public function getChannelsByQueuePoolName($queuePoolName);
+    public function getChannelsByQueuePoolName(string $queuePoolName, ?string $locale);
 
     /**
      * @param string $storeName
+     * @param string|null $locale
      *
      * @return \PhpAmqpLib\Channel\AMQPChannel[]
      */
-    public function getChannelsByStoreName($storeName);
+    public function getChannelsByStoreName(string $storeName, ?string $locale);
 
     /**
      * @return \PhpAmqpLib\Channel\AMQPChannel

--- a/src/Spryker/Client/RabbitMq/Model/Publisher/Publisher.php
+++ b/src/Spryker/Client/RabbitMq/Model/Publisher/Publisher.php
@@ -85,11 +85,17 @@ class Publisher implements PublisherInterface
     protected function getChannels(QueueSendMessageTransfer $queueSendMessageTransfer)
     {
         if ($queueSendMessageTransfer->getStoreName()) {
-            return $this->connectionManager->getChannelsByStoreName($queueSendMessageTransfer->getStoreName());
+            return $this->connectionManager->getChannelsByStoreName(
+                $queueSendMessageTransfer->getStoreName(),
+                $queueSendMessageTransfer->getLocale()
+            );
         }
 
         if ($queueSendMessageTransfer->getQueuePoolName()) {
-            return $this->connectionManager->getChannelsByQueuePoolName($queueSendMessageTransfer->getQueuePoolName());
+            return $this->connectionManager->getChannelsByQueuePoolName(
+                $queueSendMessageTransfer->getQueuePoolName(),
+                $queueSendMessageTransfer->getLocale()
+            );
         }
 
         return [$this->connectionManager->getDefaultChannel()];


### PR DESCRIPTION
- Developer(s): @sokyrko 

- Ticket: https://spryker.atlassian.net/browse/CC-777

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq              | minor                 | Store                      |

#### Release Notes

This release enabled the filtering queue connection by locale for stores and queue pools.

-----------------------------------------

#### Module RabbitMq

_**Minor:** Added functionality in a backwards-compatible manner_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Improvements

- Connection manager has been improved for separated locales and stores


