### PR TITLE
If a second connection object was destroyed this will create an error.

### DIFF
--- a/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
@@ -172,7 +172,7 @@ class Connection implements ConnectionInterface
     {
         try {
             $this->close();
-        } catch  (AMQPProtocolChannelException $e) {
+        } catch (AMQPProtocolChannelException $e) {
             // Exchange was likely deleted previously
             return;
         }

--- a/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
@@ -10,6 +10,7 @@ namespace Spryker\Client\RabbitMq\Model\Connection;
 use Generated\Shared\Transfer\QueueConnectionTransfer;
 use Generated\Shared\Transfer\RabbitMqOptionTransfer;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use Spryker\Client\RabbitMq\Model\Helper\QueueEstablishmentHelperInterface;
 
 class Connection implements ConnectionInterface
@@ -169,6 +170,11 @@ class Connection implements ConnectionInterface
 
     public function __destruct()
     {
-        $this->close();
+        try {
+            $this->close();
+        } catch  (AMQPProtocolChannelException $e) {
+            // Exchange was likely deleted previously
+            return;
+        }
     }
 }


### PR DESCRIPTION
- Developer(s): @Incognito

- Ticket: https://spryker.atlassian.net/browse/CC-880

- Academy PR: N/A

- Release Group: https://release.spryker.com/release-groups/view/493


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq              | patch                 |                       |

#### Release Notes

Fixes problem related to closing a connection twice by catching AMQPProtocolChannelException on connection destruction.

-----------------------------------------

#### Module RabbitMq

_**Patch:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] The change is isolated and not mixed with any cleanups or other changes.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Bugfixes

Fixes problem related to closing a connection twice by catching AMQPProtocolChannelException on connection destruction.

