### PR TITLE
TE-28: Fixed return types in Queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=7.1",
     "php-amqplib/php-amqplib": "^2.6",
     "spryker/kernel": "^3.20.0",
-    "spryker/queue": "^1.1.2",
+    "spryker/queue": "^1.4.0",
     "spryker/store": "^1.9.0",
     "spryker/transfer": "^3.6.0"
   },

--- a/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapter.php
+++ b/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapter.php
@@ -114,21 +114,21 @@ class RabbitMqAdapter implements RabbitMqAdapterInterface
     /**
      * @param \Generated\Shared\Transfer\QueueReceiveMessageTransfer $queueReceiveMessageTransfer
      *
-     * @return bool
+     * @return void
      */
     public function acknowledge(QueueReceiveMessageTransfer $queueReceiveMessageTransfer)
     {
-        return $this->consumer->acknowledge($queueReceiveMessageTransfer);
+        $this->consumer->acknowledge($queueReceiveMessageTransfer);
     }
 
     /**
      * @param \Generated\Shared\Transfer\QueueReceiveMessageTransfer $queueReceiveMessageTransfer
      *
-     * @return bool
+     * @return void
      */
     public function reject(QueueReceiveMessageTransfer $queueReceiveMessageTransfer)
     {
-        return $this->consumer->reject($queueReceiveMessageTransfer);
+        $this->consumer->reject($queueReceiveMessageTransfer);
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @ostrizhny

- Ticket: https://spryker.atlassian.net/browse/TE-28

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/1107

- Release Overview: https://release.spryker.com/release/pull-request-core/RabbitMq/25

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq                 | minor          |       Queue                |

#### Release Notes

Corrected return types in RabbitMq for `acknowledge()` and `reject()` methods

-----------------------------------------

#### Module RabbitMq

##### Change log

Improvements

- Fixed return type for `\Spryker\Client\RabbitMq\Model\RabbitMqAdapter::acknowledge()`.
- Fixed return type for `\Spryker\Client\RabbitMq\Model\RabbitMqAdapter::reject()`.
