### PR TITLE
[REVIEW][bug] Made api scheme configurable

### DIFF
--- a/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
+++ b/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
@@ -37,6 +37,14 @@ interface RabbitMqEnv extends QueueConstants
 
     /**
      * Specification:
+     * - Use this constant to configure the scheme of a RabbitMQ connection.
+     *
+     * @api
+     */
+    public const RABBITMQ_SCHEME = 'RABBITMQ:RABBITMQ_SCHEME';
+
+    /**
+     * Specification:
      * - Use this constant to configure the host of a RabbitMQ connection.
      *
      * @api

--- a/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
@@ -23,7 +23,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             $this->getApiScheme(),
             $this->getApiHost(),
             $this->getApiPort(),
-            urlencode(c)
+            urlencode($this->getApiVirtualHost())
         );
     }
 

--- a/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
@@ -105,8 +105,8 @@ class RabbitMqConfig extends AbstractBundleConfig
     }
 
      /**
-     * @return string
-     */
+      * @return string
+      */
     protected function getApiScheme()
     {
         return $this->get(RabbitMqEnv::RABBITMQ_SCHEME, 'http');

--- a/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
@@ -19,10 +19,11 @@ class RabbitMqConfig extends AbstractBundleConfig
     public function getApiExchangesUrl()
     {
         return sprintf(
-            'http://%s:%s/api/exchanges/%s',
+            '%s://%s:%s/api/exchanges/%s',
+            $this->getApiScheme(),
             $this->getApiHost(),
             $this->getApiPort(),
-            urlencode($this->getApiVirtualHost())
+            urlencode(c)
         );
     }
 
@@ -32,7 +33,8 @@ class RabbitMqConfig extends AbstractBundleConfig
     public function getApiQueuesUrl()
     {
         return sprintf(
-            'http://%s:%s/api/queues/%s',
+            '%s://%s:%s/api/queues/%s',
+            $this->getApiScheme(),
             $this->getApiHost(),
             $this->getApiPort(),
             urlencode($this->getApiVirtualHost())
@@ -45,7 +47,8 @@ class RabbitMqConfig extends AbstractBundleConfig
     public function getApiUserPermissionsUrl()
     {
         return sprintf(
-            'http://%s:%s/api/permissions/%s/%s',
+            '%s://%s:%s/api/permissions/%s/%s',
+            $this->getApiScheme(),
             $this->getApiHost(),
             $this->getApiPort(),
             urlencode($this->getApiVirtualHost()),
@@ -99,5 +102,13 @@ class RabbitMqConfig extends AbstractBundleConfig
     protected function getApiPort()
     {
         return $this->get(RabbitMqEnv::RABBITMQ_API_PORT);
+    }
+
+     /**
+     * @return string
+     */
+    protected function getApiScheme()
+    {
+        return $this->get(RabbitMqEnv::RABBITMQ_SCHEME);
     }
 }

--- a/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
@@ -109,6 +109,6 @@ class RabbitMqConfig extends AbstractBundleConfig
      */
     protected function getApiScheme()
     {
-        return $this->get(RabbitMqEnv::RABBITMQ_SCHEME);
+        return $this->get(RabbitMqEnv::RABBITMQ_SCHEME, 'http');
     }
 }


### PR DESCRIPTION
In order to communicate with 3rd party rabbit providers https schemes are required. (https://cloudamqp.com)