### PR TITLE
TE-3485: P&S new structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
 
   fast_finish: true
 
+  allow_failures:
+      -   php: 7.2
+      -   php: 7.4snapshot
+
 before_install:
   - if [[ ${TRAVIS_PHP_VERSION} != "7.4snapshot" ]]; then phpenv config-rm xdebug.ini ; fi
   - phpenv config-add ci/travis.php.ini

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -52,6 +52,31 @@ class RabbitMqConfig extends AbstractBundleConfig
     /**
      * @return array
      */
+    public function getMessageConfig(): array
+    {
+        return [
+            'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
+        ];
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\QueueConnectionTransfer
+     */
+    public function getDefaultQueueConnectionConfig(): QueueConnectionTransfer
+    {
+        return (new QueueConnectionTransfer())
+            ->setInsist(static::AMQP_STREAM_CONNECTION_INSIST)
+            ->setLoginMethod(static::AMQP_STREAM_CONNECTION_LOGIN_METHOD)
+            ->setConnectionTimeout(static::AMQP_STREAM_CONNECTION_CONNECTION_TIMEOUT)
+            ->setReadWriteTimeout(static::AMQP_STREAM_CONNECTION_READ_WRITE_TIMEOUT)
+            ->setKeepAlive(static::AMQP_STREAM_CONNECTION_KEEP_ALIVE)
+            ->setHeartBeat(static::AMQP_STREAM_CONNECTION_HEART_BEAT)
+            ->setChannelRpcTimeout(static::AMQP_STREAM_CONNECTION_CHANNEL_RPC_TIMEOUT);
+    }
+
+    /**
+     * @return array
+     */
     protected function getQueueConnectionConfigs(): array
     {
         $connections = [];
@@ -109,31 +134,6 @@ class RabbitMqConfig extends AbstractBundleConfig
     protected function getQueueConfiguration(): array
     {
         return [];
-    }
-
-    /**
-     * @return array
-     */
-    public function getMessageConfig(): array
-    {
-        return [
-            'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
-        ];
-    }
-
-    /**
-     * @return \Generated\Shared\Transfer\QueueConnectionTransfer
-     */
-    public function getDefaultQueueConnectionConfig(): QueueConnectionTransfer
-    {
-        return (new QueueConnectionTransfer())
-            ->setInsist(static::AMQP_STREAM_CONNECTION_INSIST)
-            ->setLoginMethod(static::AMQP_STREAM_CONNECTION_LOGIN_METHOD)
-            ->setConnectionTimeout(static::AMQP_STREAM_CONNECTION_CONNECTION_TIMEOUT)
-            ->setReadWriteTimeout(static::AMQP_STREAM_CONNECTION_READ_WRITE_TIMEOUT)
-            ->setKeepAlive(static::AMQP_STREAM_CONNECTION_KEEP_ALIVE)
-            ->setHeartBeat(static::AMQP_STREAM_CONNECTION_HEART_BEAT)
-            ->setChannelRpcTimeout(static::AMQP_STREAM_CONNECTION_CHANNEL_RPC_TIMEOUT);
     }
 
     /**

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -115,8 +115,6 @@ class RabbitMqConfig extends AbstractBundleConfig
 
         foreach ($queueConfigurations as $queueNameKey => $queueConfiguration) {
             if (!is_array($queueConfiguration)) {
-                $this->queueOptionCollection->append($this->createQueueOption($queueConfiguration, sprintf('%s.error', $queueConfiguration), 'error'));
-
                 continue;
             }
 
@@ -152,7 +150,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setType('direct')
             ->setDeclarationType(Connection::RABBIT_MQ_EXCHANGE)
             ->addBindingQueueItem($this->createQueueBinding($queueName))
-            ->addBindingQueueItem($this->createErrorQueueBinding($boundQueueName, $routingKey));
+            ->addBindingQueueItem($this->createQueueBinding($queueName));
 
         return $queueOptionTransfer;
     }
@@ -170,24 +168,6 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setDurable(true)
             ->setNoWait(false)
             ->addRoutingKey('');
-
-        return $queueOptionTransfer;
-    }
-
-    /**
-     * @param string $errorQueueName
-     * @param string $routingKey
-     *
-     * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
-     */
-    protected function createErrorQueueBinding($errorQueueName, $routingKey)
-    {
-        $queueOptionTransfer = new RabbitMqOptionTransfer();
-        $queueOptionTransfer
-            ->setQueueName($errorQueueName)
-            ->setDurable(true)
-            ->setNoWait(false)
-            ->addRoutingKey($routingKey);
 
         return $queueOptionTransfer;
     }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -115,7 +115,9 @@ class RabbitMqConfig extends AbstractBundleConfig
 
         foreach ($queueConfigurations as $queueNameKey => $queueConfiguration) {
             if (!is_array($queueConfiguration)) {
-                $this->queueOptionCollection->append($this->createQueueOption($queueConfiguration, $queueConfiguration));
+                $this->queueOptionCollection->append(
+                    $this->createQueueOptionWithBoundedQueueName($queueConfiguration, $queueConfiguration)
+                );
                 continue;
             }
 
@@ -125,6 +127,18 @@ class RabbitMqConfig extends AbstractBundleConfig
         }
 
         return $this->queueOptionCollection;
+    }
+
+    /**
+     * @param string $queueName
+     * @param string $boundQueueName
+     * @param string $routingKey
+     *
+     * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
+     */
+    protected function createQueueOptionWithBoundedQueueName($queueName, $boundQueueName, $routingKey = '')
+    {
+        return $this->createQueueOption($queueName, $boundQueueName, $routingKey);
     }
 
     /**
@@ -151,24 +165,25 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setType('direct')
             ->setDeclarationType(Connection::RABBIT_MQ_EXCHANGE)
             ->addBindingQueueItem($this->createQueueBinding($queueName))
-            ->addBindingQueueItem($this->createQueueBinding($boundQueueName));
+            ->addBindingQueueItem($this->createQueueBinding($boundQueueName, $routingKey));
 
         return $queueOptionTransfer;
     }
 
     /**
      * @param string $queueName
+     * @param string $routingKey
      *
      * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
      */
-    protected function createQueueBinding($queueName)
+    protected function createQueueBinding($queueName, $routingKey = '')
     {
         $queueOptionTransfer = new RabbitMqOptionTransfer();
         $queueOptionTransfer
             ->setQueueName($queueName)
             ->setDurable(true)
             ->setNoWait(false)
-            ->addRoutingKey('');
+            ->addRoutingKey($routingKey);
 
         return $queueOptionTransfer;
     }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -115,6 +115,7 @@ class RabbitMqConfig extends AbstractBundleConfig
 
         foreach ($queueConfigurations as $queueNameKey => $queueConfiguration) {
             if (!is_array($queueConfiguration)) {
+                $this->queueOptionCollection->append($this->createQueueOption($queueConfiguration, $queueConfiguration));
                 continue;
             }
 
@@ -141,7 +142,7 @@ class RabbitMqConfig extends AbstractBundleConfig
      *
      * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
      */
-    protected function createQueueOption($queueName, $boundQueueName, $routingKey)
+    protected function createQueueOption($queueName, $boundQueueName, $routingKey = '')
     {
         $queueOptionTransfer = new RabbitMqOptionTransfer();
         $queueOptionTransfer
@@ -150,7 +151,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setType('direct')
             ->setDeclarationType(Connection::RABBIT_MQ_EXCHANGE)
             ->addBindingQueueItem($this->createQueueBinding($queueName))
-            ->addBindingQueueItem($this->createQueueBinding($queueName));
+            ->addBindingQueueItem($this->createQueueBinding($boundQueueName));
 
         return $queueOptionTransfer;
     }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -165,7 +165,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setType('direct')
             ->setDeclarationType(Connection::RABBIT_MQ_EXCHANGE)
             ->addBindingQueueItem($this->createQueueBinding($queueName))
-            ->addBindingQueueItem($this->createQueueBinding($boundQueueName, $routingKey));
+            ->addBindingQueueItem($this->createQueueBinding($boundQueueName));
 
         return $queueOptionTransfer;
     }
@@ -176,14 +176,14 @@ class RabbitMqConfig extends AbstractBundleConfig
      *
      * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
      */
-    protected function createQueueBinding($queueName, $routingKey = '')
+    protected function createQueueBinding($queueName)
     {
         $queueOptionTransfer = new RabbitMqOptionTransfer();
         $queueOptionTransfer
             ->setQueueName($queueName)
             ->setDurable(true)
             ->setNoWait(false)
-            ->addRoutingKey($routingKey);
+            ->addRoutingKey('');
 
         return $queueOptionTransfer;
     }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -116,8 +116,10 @@ class RabbitMqConfig extends AbstractBundleConfig
         foreach ($queueConfigurations as $queueNameKey => $queueConfiguration) {
             if (!is_array($queueConfiguration)) {
                 $defaultBoundQueueNamePrefix = $this->getDefaultBoundQueueNamePrefix();
+                $boundQueueName = $defaultBoundQueueNamePrefix === "" ? $queueConfiguration : sprintf('%s.%s', $queueConfiguration, $defaultBoundQueueNamePrefix);
+
                 $this->queueOptionCollection->append(
-                    $this->createExchangeOptionTransfer($queueConfiguration, sprintf('%s.%s', $queueConfiguration, $defaultBoundQueueNamePrefix), $defaultBoundQueueNamePrefix)
+                    $this->createExchangeOptionTransfer($queueConfiguration, $boundQueueName, $defaultBoundQueueNamePrefix)
                 );
                 continue;
             }
@@ -133,19 +135,19 @@ class RabbitMqConfig extends AbstractBundleConfig
     }
 
     /**
-     * @return string
-     */
-    protected function getDefaultBoundQueueNamePrefix(): string
-    {
-        return '';
-    }
-
-    /**
      * @return array
      */
     protected function getQueueConfiguration(): array
     {
         return [];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultBoundQueueNamePrefix(): string
+    {
+        return '';
     }
 
     /**
@@ -163,7 +165,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setDurable(true)
             ->setType('direct')
             ->setDeclarationType(Connection::RABBIT_MQ_EXCHANGE)
-            ->addBindingQueueItem($this->createQueueOptionTransfer($queueName, $routingKey))
+            ->addBindingQueueItem($this->createQueueOptionTransfer($queueName))
             ->addBindingQueueItem($this->createQueueOptionTransfer($boundQueueName, $routingKey));
 
         return $queueOptionTransfer;

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -163,29 +163,29 @@ class RabbitMqConfig extends AbstractBundleConfig
      *
      * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
      */
-    protected function createQueueBinding($queueName, $routingKey = '')
+    protected function createQueueBinding($queueName)
     {
         $queueOptionTransfer = new RabbitMqOptionTransfer();
         $queueOptionTransfer
             ->setQueueName($queueName)
             ->setDurable(true)
             ->setNoWait(false)
-            ->addRoutingKey($routingKey);
+            ->addRoutingKey('');
 
         return $queueOptionTransfer;
     }
 
     /**
-     * @param string $boundQueueName
+     * @param string $errorQueueName
      * @param string $routingKey
      *
      * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
      */
-    protected function createBoundQueueBinding($boundQueueName, $routingKey)
+    protected function createErrorQueueBinding($errorQueueName, $routingKey)
     {
         $queueOptionTransfer = new RabbitMqOptionTransfer();
         $queueOptionTransfer
-            ->setQueueName($boundQueueName)
+            ->setQueueName($errorQueueName)
             ->setDurable(true)
             ->setNoWait(false)
             ->addRoutingKey($routingKey);

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -159,7 +159,6 @@ class RabbitMqConfig extends AbstractBundleConfig
 
     /**
      * @param string $queueName
-     * @param string $routingKey
      *
      * @return \Generated\Shared\Transfer\RabbitMqOptionTransfer
      */

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -152,7 +152,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setType('direct')
             ->setDeclarationType(Connection::RABBIT_MQ_EXCHANGE)
             ->addBindingQueueItem($this->createQueueBinding($queueName))
-            ->addBindingQueueItem($this->createBoundQueueBinding($boundQueueName, $routingKey));
+            ->addBindingQueueItem($this->createErrorQueueBinding($boundQueueName, $routingKey));
 
         return $queueOptionTransfer;
     }


### PR DESCRIPTION
- Developer(s): @alexanderM91 

- Ticket: https://spryker.atlassian.net/browse/TE-3485

- Suite nonsplit PR: spryker/suite-nonsplit#2194

- CORE PR: https://github.com/spryker/spryker/pull/5281

- EventBehavior: https://github.com/spryker/event-behavior/pull/48

- Release Group: https://release.spryker.com/release-groups/view/1414

- Release Overview: https://release.spryker.com/release/pull-request/4460

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq       | minor                 |                         |

#### Release Notes

-----------------------------------------

#### Module RabbitMq

##### Change log

### Improvements

- Adjusted RabbitMQ configuration so queue and exchange creation are handled by default.