### PR TITLE
SOL-58: Sync:data commands gets slower while consumers (queue - workers) are running

### DIFF
--- a/src/Spryker/Client/RabbitMq/Model/Manager/Manager.php
+++ b/src/Spryker/Client/RabbitMq/Model/Manager/Manager.php
@@ -77,4 +77,20 @@ class Manager implements ManagerInterface
     {
         return $this->channel->exchange_delete($exchangeName);
     }
+
+    /**
+     * @param string $queueName
+     *
+     * @return int|null
+     */
+    public function getQueueSize(string $queueName): ?int
+    {
+        $result = $this->channel->queue_declare($queueName, true);
+
+        if ($result !== null && isset($result[1])) {
+            return (int) $result[1];
+        }
+
+        return null;
+    }
 }

--- a/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapter.php
+++ b/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapter.php
@@ -162,4 +162,15 @@ class RabbitMqAdapter implements RabbitMqAdapterInterface
     {
         $this->publisher->sendMessages($queueName, $queueSendMessageTransfers);
     }
+
+
+    /**
+     * @param string $queueName
+     *
+     * @return int|null
+     */
+    public function getQueueSize(string $queueName): ?int
+    {
+        return $this->manager->getQueueSize($queueName);
+    }
 }


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/SOL-58

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq  | minor         | Queue|

#### Release Notes

{skip}

-----------------------------------------

#### Module RabbitMq

##### Change log

Improvements

- Introduced `RabbitMqAdapter::getQueueSize` method which allow to get queue size by the given queue name.
