### PR TITLE
TE-10704 Fixed message about not supported return type and added message for absent param type

### DIFF
--- a/architecture-baseline.json
+++ b/architecture-baseline.json
@@ -8,14 +8,14 @@
     },
     {
         "fileName": "src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleBridge.php",
-        "description": "Bridges: Type hint should be defined for param `uri` in method `Spryker\\Zed\\RabbitMq\\Dependency\\Guzzle\\RabbitMqToGuzzleBridge::get()`.",
+        "description": "Bridges: Type should be defined for param `uri` in method `Spryker\\Zed\\RabbitMq\\Dependency\\Guzzle\\RabbitMqToGuzzleBridge::get()`.",
         "rule": "BridgeMethodsRule",
         "ruleset": "Spryker",
         "priority": "2"
     },
     {
         "fileName": "src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleBridge.php",
-        "description": "Bridges: Type hint should be defined for param `uri` in method `Spryker\\Zed\\RabbitMq\\Dependency\\Guzzle\\RabbitMqToGuzzleBridge::put()`.",
+        "description": "Bridges: Type should be defined for param `uri` in method `Spryker\\Zed\\RabbitMq\\Dependency\\Guzzle\\RabbitMqToGuzzleBridge::put()`.",
         "rule": "BridgeMethodsRule",
         "ruleset": "Spryker",
         "priority": "2"

--- a/architecture-baseline.json
+++ b/architecture-baseline.json
@@ -7,6 +7,20 @@
         "priority": "2"
     },
     {
+        "fileName": "src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleBridge.php",
+        "description": "Bridges: Type hint should be defined for param `uri` in method `Spryker\\Zed\\RabbitMq\\Dependency\\Guzzle\\RabbitMqToGuzzleBridge::get()`.",
+        "rule": "BridgeMethodsRule",
+        "ruleset": "Spryker",
+        "priority": "2"
+    },
+    {
+        "fileName": "src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleBridge.php",
+        "description": "Bridges: Type hint should be defined for param `uri` in method `Spryker\\Zed\\RabbitMq\\Dependency\\Guzzle\\RabbitMqToGuzzleBridge::put()`.",
+        "rule": "BridgeMethodsRule",
+        "ruleset": "Spryker",
+        "priority": "2"
+    },
+    {
         "fileName": "src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleInterface.php",
         "description": "Bridges: The bridge interface has incorrect method signature for `get()`. Missed return type. That violates the rule \"All bridge interface methods must have exactly the same or more strict signature as their parent\"",
         "rule": "BridgeMethodsInterfaceRule",


### PR DESCRIPTION
Ticker: https://spryker.atlassian.net/browse/TE-10704

Architecture sniffer PR: https://github.com/spryker/architecture-sniffer/pull/109