### PR TITLE
RabbitMQ heart beat configuration and checking if connection is open

### DIFF
--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
@@ -69,8 +69,10 @@ class ConnectionBuilder implements ConnectionBuilderInterface
      */
     protected function createOrGetConnection(QueueConnectionTransfer $queueConnectionTransfer): ConnectionInterface
     {
-        if (isset($this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()])) {
-            return $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()];
+        $connection = $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()] ?? null;
+
+        if ($connection !== null && $connection->getChannel()->is_open()) {
+            return $connection;
         }
 
         $connection = $this->createConnection($queueConnectionTransfer);

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -103,7 +103,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setConnectionTimeout(static::AMQP_STREAM_CONNECTION_CONNECTION_TIMEOUT)
             ->setReadWriteTimeout(static::AMQP_STREAM_CONNECTION_READ_WRITE_TIMEOUT)
             ->setKeepAlive(static::AMQP_STREAM_CONNECTION_KEEP_ALIVE)
-            ->setHeartBeat(static::AMQP_STREAM_CONNECTION_HEART_BEAT)
+            ->setHeartBeat($this->getHeartBeat())
             ->setChannelRpcTimeout(static::AMQP_STREAM_CONNECTION_CHANNEL_RPC_TIMEOUT);
     }
 
@@ -275,5 +275,13 @@ class RabbitMqConfig extends AbstractBundleConfig
     public function isDynamicStoreEnabled(): bool
     {
         return (bool)getenv('SPRYKER_DYNAMIC_STORE_MODE');
+    }
+
+    /**
+     * @return int
+     */
+    protected function getHeartBeat(): int
+    {
+        return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, 0);
     }
 }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -278,10 +278,12 @@ class RabbitMqConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     protected function getHeartBeat(): int
     {
-        return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, 0);
+        return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, static::AMQP_STREAM_CONNECTION_HEART_BEAT);
     }
 }

--- a/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
+++ b/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
@@ -189,4 +189,14 @@ interface RabbitMqEnv extends QueueConstants
      * @var string
      */
     public const RABBITMQ_ENABLE_RUNTIME_SETTING_UP = 'RABBITMQ:RABBITMQ_ENABLE_RUNTIME_SETTING_UP';
+
+    /**
+     * Specification:
+     * - Use this constant to define the available RabbitMQ heartbeat in seconds.
+     *
+     * @api
+     *
+     * @var string
+     */
+    public const RABBITMQ_HEART_BEAT_SECONDS = 'RABBITMQ:RABBITMQ_HEART_BEAT_SECONDS';
 }


### PR DESCRIPTION
Added RabbitMQ heartbeat configuration
Added checking if a connection is open in ConnectionBuilder

## PR Description

When someone or something sends to our process SIGKILL, our process stops without closing the connection to RabbitMQ.
A common issue for Data Exchanging Api via glue-backend.
Setting a heartbeat resolves it.
I am going to add an article to the public doc to set the value - 180 sec

Also, long-running processes like queue worker can come across issues with closed connections after 5-10 minutes so the fix allows us to prevent using closed connections and open a new one

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
