### PR TITLE
FRW-8637 Added RabbitMq Heartbeat configuration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "spryker/kernel": "^3.56.0",
         "spryker/log": "^3.7.0",
         "spryker/queue": "^1.5.0",
-        "spryker/store": "^1.10.0",
+        "spryker/store": "^1.19.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/testify": "^3.50.0"
+        "spryker/testify": "^3.49.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "spryker/kernel": "^3.56.0",
         "spryker/log": "^3.7.0",
         "spryker/queue": "^1.5.0",
-        "spryker/store": "^1.23.0",
+        "spryker/store": "^1.21.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "spryker/kernel": "^3.56.0",
         "spryker/log": "^3.7.0",
         "spryker/queue": "^1.5.0",
-        "spryker/store": "^1.21.0",
+        "spryker/store": "^1.20.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "spryker/kernel": "^3.56.0",
         "spryker/log": "^3.7.0",
         "spryker/queue": "^1.5.0",
-        "spryker/store": "^1.19.0",
+        "spryker/store": "^1.23.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "spryker/kernel": "^3.56.0",
         "spryker/log": "^3.7.0",
         "spryker/queue": "^1.5.0",
-        "spryker/store": "^1.20.0",
+        "spryker/store": "^1.21.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1"
     },
@@ -20,7 +20,7 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/testify": "^3.47.0"
+        "spryker/testify": "^3.50.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/testify": "^3.48.0"
+        "spryker/testify": "^3.49.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/testify": "^3.49.0"
+        "spryker/testify": "^3.48.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
@@ -69,9 +69,8 @@ class ConnectionBuilder implements ConnectionBuilderInterface
      */
     protected function createOrGetConnection(QueueConnectionTransfer $queueConnectionTransfer): ConnectionInterface
     {
-        $connection = $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()] ?? null;
-
-        if ($connection !== null && $connection->getChannel() !== null && $connection->getChannel()->is_open()) {
+        $connection = $this->getWorkingConnection($queueConnectionTransfer);
+        if ($connection !== null) {
             return $connection;
         }
 
@@ -79,6 +78,22 @@ class ConnectionBuilder implements ConnectionBuilderInterface
         $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()] = $connection;
 
         return $connection;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\QueueConnectionTransfer $queueConnectionTransfer
+     *
+     * @return \Spryker\Client\RabbitMq\Model\Connection\ConnectionInterface|null
+     */
+    protected function getWorkingConnection(QueueConnectionTransfer $queueConnectionTransfer): ?ConnectionInterface
+    {
+        $connection = $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()] ?? null;
+
+        if ($connection !== null && $connection->getChannel() !== null && $connection->getChannel()->is_open()) {
+            return $connection;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
@@ -71,7 +71,7 @@ class ConnectionBuilder implements ConnectionBuilderInterface
     {
         $connection = $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()] ?? null;
 
-        if ($connection !== null && $connection->getChannel()->is_open()) {
+        if ($connection !== null && $connection->getChannel() !== null && $connection->getChannel()->is_open()) {
             return $connection;
         }
 

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
@@ -69,8 +69,10 @@ class ConnectionBuilder implements ConnectionBuilderInterface
      */
     protected function createOrGetConnection(QueueConnectionTransfer $queueConnectionTransfer): ConnectionInterface
     {
-        if (isset($this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()])) {
-            return $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()];
+        $connection = $this->createdConnectionsByConnectionName[$queueConnectionTransfer->getName()] ?? null;
+
+        if ($connection !== null && $connection->getChannel()->is_open()) {
+            return $connection;
         }
 
         $connection = $this->createConnection($queueConnectionTransfer);

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -278,6 +278,9 @@ class RabbitMqConfig extends AbstractBundleConfig
     }
 
     /**
+     * Specification:
+     * - Returns the heart beat value for the RabbitMQ connection.
+     *
      * @api
      *
      * @return int

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -282,7 +282,7 @@ class RabbitMqConfig extends AbstractBundleConfig
      *
      * @return int
      */
-    protected function getHeartBeat(): int
+    public function getHeartBeat(): int
     {
         return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, static::AMQP_STREAM_CONNECTION_HEART_BEAT);
     }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -103,7 +103,7 @@ class RabbitMqConfig extends AbstractBundleConfig
             ->setConnectionTimeout(static::AMQP_STREAM_CONNECTION_CONNECTION_TIMEOUT)
             ->setReadWriteTimeout(static::AMQP_STREAM_CONNECTION_READ_WRITE_TIMEOUT)
             ->setKeepAlive(static::AMQP_STREAM_CONNECTION_KEEP_ALIVE)
-            ->setHeartBeat(static::AMQP_STREAM_CONNECTION_HEART_BEAT)
+            ->setHeartBeat($this->getHeartBeat())
             ->setChannelRpcTimeout(static::AMQP_STREAM_CONNECTION_CHANNEL_RPC_TIMEOUT);
     }
 
@@ -275,5 +275,13 @@ class RabbitMqConfig extends AbstractBundleConfig
     public function isDynamicStoreEnabled(): bool
     {
         return (bool)getenv('SPRYKER_DYNAMIC_STORE_MODE');
+    }
+
+    /**
+     * @return int
+     */
+    protected function getHeartBeat(): int
+    {
+        return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, 0);
     }
 }

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -278,10 +278,12 @@ class RabbitMqConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     protected function getHeartBeat(): int
     {
-        return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, 0);
+        return (int)$this->get(RabbitMqEnv::RABBITMQ_HEART_BEAT_SECONDS, static::AMQP_STREAM_CONNECTION_HEART_BEAT);
     }
 }

--- a/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
+++ b/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
@@ -189,4 +189,14 @@ interface RabbitMqEnv extends QueueConstants
      * @var string
      */
     public const RABBITMQ_ENABLE_RUNTIME_SETTING_UP = 'RABBITMQ:RABBITMQ_ENABLE_RUNTIME_SETTING_UP';
+
+    /**
+     * Specification:
+     * - Use this constant to define the available RabbitMQ heartbeat in seconds.
+     *
+     * @api
+     *
+     * @var string
+     */
+    public const RABBITMQ_HEART_BEAT_SECONDS = 'RABBITMQ:RABBITMQ_HEART_BEAT_SECONDS';
 }

--- a/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
+++ b/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace SprykerTest\Client\RabbitMq\Model\Connection\ConnectionBuilder;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\QueueConnectionTransfer;
+use PhpAmqpLib\Channel\AMQPChannel;
+use ReflectionClass;
+use Spryker\Client\RabbitMq\Model\Connection\ConnectionBuilder\ConnectionBuilder;
+use Spryker\Client\RabbitMq\Model\Connection\ConnectionInterface;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Client
+ * @group RabbitMq
+ * @group Model
+ * @group Connection
+ * @group ConnectionBuilder
+ * @group ConnectionBuilderTest
+ * Add your own group annotations below this line
+ */
+class ConnectionBuilderTest extends Unit
+{
+    /**
+     * @var \SprykerTest\Client\RabbitMq\RabbitMqClientTester
+     */
+    protected $tester;
+
+    /**
+     * @return void
+     */
+    public function testReturnsExistingConnectionIfAlreadyCreatedAndChannelIsOpen(): void
+    {
+        // Arrange
+        $queueConnectionTransfer = $this->createMock(QueueConnectionTransfer::class);
+        $queueConnectionTransfer->method('getName')->willReturn('test_connection');
+
+        $channel = $this->createMock(AMQPChannel::class);
+        $channel->method('is_open')->willReturn(true);
+
+        $existingConnection = $this->createMock(ConnectionInterface::class);
+        $existingConnection->method('getChannel')->willReturn($channel);
+
+        $connectionBuilder = $this->getMockBuilder(ConnectionBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['createConnection'])
+            ->getMock();
+        $reflection = new ReflectionClass(ConnectionBuilder::class);
+        $property = $reflection->getProperty('createdConnectionsByConnectionName');
+        $property->setAccessible(true);
+        $property->setValue($connectionBuilder, ['test_connection' => $existingConnection]);
+
+        // Act
+        $result = $connectionBuilder->createConnectionByQueueConnectionTransfer($queueConnectionTransfer);
+
+        // Assert
+        $this->assertSame($existingConnection, $result);
+    }
+}

--- a/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
+++ b/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
@@ -13,6 +13,7 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use ReflectionClass;
 use Spryker\Client\RabbitMq\Model\Connection\ConnectionBuilder\ConnectionBuilder;
 use Spryker\Client\RabbitMq\Model\Connection\ConnectionInterface;
+use SprykerTest\Client\RabbitMq\RabbitMqClientTester;
 
 /**
  * Auto-generated group annotations
@@ -31,7 +32,7 @@ class ConnectionBuilderTest extends Unit
     /**
      * @var \SprykerTest\Client\RabbitMq\RabbitMqClientTester
      */
-    protected $tester;
+    protected RabbitMqClientTester $tester;
 
     /**
      * @return void

--- a/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
+++ b/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
@@ -11,11 +11,8 @@ use Codeception\Test\Unit;
 use Generated\Shared\Transfer\QueueConnectionTransfer;
 use PhpAmqpLib\Channel\AMQPChannel;
 use ReflectionClass;
-use Spryker\Client\RabbitMq\Dependency\Client\RabbitMqToStoreClientInterface;
 use Spryker\Client\RabbitMq\Model\Connection\ConnectionBuilder\ConnectionBuilder;
 use Spryker\Client\RabbitMq\Model\Connection\ConnectionInterface;
-use Spryker\Client\RabbitMq\Model\Helper\QueueEstablishmentHelperInterface;
-use Spryker\Client\RabbitMq\RabbitMqConfig;
 
 /**
  * Auto-generated group annotations
@@ -67,6 +64,9 @@ class ConnectionBuilderTest extends Unit
         $this->assertSame($existingConnection, $result);
     }
 
+    /**
+     * @return void
+     */
     public function testCreatesNewConnectionIfNoExistingConnectionFound(): void
     {
         // Arrange
@@ -88,25 +88,9 @@ class ConnectionBuilderTest extends Unit
         $this->assertSame($newConnection, $result);
     }
 
-    public function testHandlesNullOrEmptyQueueConnectionTransferName(): void
-    {
-        // Arrange
-        $queueConnectionTransfer = $this->createMock(QueueConnectionTransfer::class);
-        $queueConnectionTransfer->method('getName')->willReturn(null);
-
-        $connectionBuilder = new ConnectionBuilder(
-            $this->createMock(RabbitMqConfig::class),
-            $this->createMock(RabbitMqToStoreClientInterface::class),
-            $this->createMock(QueueEstablishmentHelperInterface::class),
-        );
-
-        // Act
-        $result = $connectionBuilder->createConnectionByQueueConnectionTransfer($queueConnectionTransfer);
-
-        // Assert
-        $this->assertNull($result);
-    }
-
+    /**
+     * @return void
+     */
     public function testHandlesEmptyCreatedConnectionsArray(): void
     {
         // Arrange
@@ -128,6 +112,9 @@ class ConnectionBuilderTest extends Unit
         $this->assertSame($newConnection, $result);
     }
 
+    /**
+     * @return void
+     */
     public function testHandlesNullChannelFromGetChannelMethod(): void
     {
         // Arrange


### PR DESCRIPTION
## PR Description

- Developer(s): @kraal-spryker

- Ticket: https://spryker.atlassian.net/browse/FRW-8637

- Release Group: [URL_HERE](https://release.spryker.com/release-groups/view/5436)
- PR Overview: https://release.spryker.com/release/pull-request-core/RabbitMq/80

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq              | minor                 |          |

-----------------------------------------

#### Module RabbitMq

##### Change log

Improvements

- Introduced `\Spryker\Client\RabbitMq\RabbitMqConfig::getHeartBeat()` config method.
- Introduced `RABBITMQ:RABBITMQ_HEART_BEAT_SECONDS` environment config.
- Adjusted `\Spryker\Client\RabbitMq\RabbitMqClient::getConnection()` client method to check and use working connections from the cache if exists.
- Increased Store module version dependency.
- Increased Testify module version dependency.

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
