### PR TITLE
FRW-1877 Fixed the Queue Worker stopping too early when using a "stop-when-empty" option.

### DIFF
--- a/.license
+++ b/.license
@@ -1,4 +1,0 @@
-/**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
- */

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "spryker/store": "^1.21.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1",
-        "spryker/spryker": "*"
+        "spryker/spryker": "dev-master"
     },
     "require-dev": {
         "codeception/module-asserts": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
         "spryker/queue": "^1.5.0",
         "spryker/store": "^1.21.0",
         "spryker/symfony": "^3.5.0",
-        "spryker/transfer": "^3.33.1",
-        "spryker/spryker": "dev-master"
+        "spryker/transfer": "^3.33.1"
     },
     "require-dev": {
         "codeception/module-asserts": "*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/testify": "^3.49.0"
+        "spryker/event": "*",
+        "spryker/testify": "^3.49.0",
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
         "spryker/event": "^2.4.0",
-        "spryker/testify": "^3.49.0",
+        "spryker/testify": "^3.49.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/event": "*",
+        "spryker/event": "^2.4.0",
         "spryker/testify": "^3.49.0",
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "codeception/stub": "^4.1",
         "mikey179/vfsstream": "^1.6.11",
         "spryker/code-sniffer": "^0.17.1",
-        "spryker/event": "^2.4.0",
         "spryker/testify": "^3.49.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "spryker/kernel": "^3.56.0",
         "spryker/log": "^3.7.0",
         "spryker/queue": "^1.5.0",
+        "spryker/queue-extension": "^1.0.0",
         "spryker/store": "^1.21.0",
         "spryker/symfony": "^3.5.0",
         "spryker/transfer": "^3.33.1"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "spryker/queue": "^1.5.0",
         "spryker/store": "^1.21.0",
         "spryker/symfony": "^3.5.0",
-        "spryker/transfer": "^3.33.1"
+        "spryker/transfer": "^3.33.1",
+        "spryker/spryker": "*"
     },
     "require-dev": {
         "codeception/module-asserts": "*",

--- a/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientBridge.php
+++ b/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientBridge.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Dependency\Client;

--- a/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientInterface.php
+++ b/src/Spryker/Client/RabbitMq/Dependency/Client/RabbitMqToStoreClientInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Dependency\Client;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilder.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection\ConnectionBuilder;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection\ConnectionBuilder;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManager.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManager.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManagerInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/ConnectionManagerInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferFilter/QueueConnectionTransferFilter.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferFilter/QueueConnectionTransferFilter.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection\QueueConnectionTransferFilter;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferFilter/QueueConnectionTransferFilterInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferFilter/QueueConnectionTransferFilterInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection\QueueConnectionTransferFilter;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferMapper/QueueConnectionTransferMapper.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferMapper/QueueConnectionTransferMapper.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection\QueueConnectionTransferMapper;

--- a/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferMapper/QueueConnectionTransferMapperInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/QueueConnectionTransferMapper/QueueConnectionTransferMapperInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Connection\QueueConnectionTransferMapper;

--- a/src/Spryker/Client/RabbitMq/Model/Consumer/Consumer.php
+++ b/src/Spryker/Client/RabbitMq/Model/Consumer/Consumer.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Consumer;

--- a/src/Spryker/Client/RabbitMq/Model/Consumer/ConsumerInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Consumer/ConsumerInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Consumer;

--- a/src/Spryker/Client/RabbitMq/Model/Exception/ConnectionConfigIsNotDefinedException.php
+++ b/src/Spryker/Client/RabbitMq/Model/Exception/ConnectionConfigIsNotDefinedException.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Exception;

--- a/src/Spryker/Client/RabbitMq/Model/Exception/DefaultConnectionNotFoundException.php
+++ b/src/Spryker/Client/RabbitMq/Model/Exception/DefaultConnectionNotFoundException.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Exception;

--- a/src/Spryker/Client/RabbitMq/Model/Helper/QueueEstablishmentHelper.php
+++ b/src/Spryker/Client/RabbitMq/Model/Helper/QueueEstablishmentHelper.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Helper;

--- a/src/Spryker/Client/RabbitMq/Model/Helper/QueueEstablishmentHelperInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Helper/QueueEstablishmentHelperInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Helper;

--- a/src/Spryker/Client/RabbitMq/Model/Manager/Manager.php
+++ b/src/Spryker/Client/RabbitMq/Model/Manager/Manager.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Manager;

--- a/src/Spryker/Client/RabbitMq/Model/Manager/ManagerInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Manager/ManagerInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Manager;

--- a/src/Spryker/Client/RabbitMq/Model/Publisher/Publisher.php
+++ b/src/Spryker/Client/RabbitMq/Model/Publisher/Publisher.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Publisher;

--- a/src/Spryker/Client/RabbitMq/Model/Publisher/PublisherInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/Publisher/PublisherInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model\Publisher;

--- a/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapter.php
+++ b/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model;

--- a/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapterInterface.php
+++ b/src/Spryker/Client/RabbitMq/Model/RabbitMqAdapterInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq\Model;

--- a/src/Spryker/Client/RabbitMq/RabbitMqClient.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqClient.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq;

--- a/src/Spryker/Client/RabbitMq/RabbitMqClientInterface.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqClientInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq;

--- a/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqConfig.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq;

--- a/src/Spryker/Client/RabbitMq/RabbitMqDependencyProvider.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqDependencyProvider.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq;

--- a/src/Spryker/Client/RabbitMq/RabbitMqFactory.php
+++ b/src/Spryker/Client/RabbitMq/RabbitMqFactory.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Client\RabbitMq;

--- a/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
+++ b/src/Spryker/Shared/RabbitMq/RabbitMqEnv.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Shared\RabbitMq;

--- a/src/Spryker/Shared/RabbitMq/Transfer/rabbit_mq.transfer.xml
+++ b/src/Spryker/Shared/RabbitMq/Transfer/rabbit_mq.transfer.xml
@@ -53,6 +53,7 @@
     </transfer>
 
     <transfer name="RabbitMqQueue">
+        <property name="messageCount" type="int" strict="true"/>
         <property name="name" type="string"/>
         <property name="virtualHost" type="string"/>
     </transfer>
@@ -90,6 +91,10 @@
         <property name="requeue" type="bool"/>
         <property name="queueMessage" type="QueueSendMessage"/>
         <property name="queueName" type="string"/>
+    </transfer>
+
+    <transfer name="RabbitMqQueueCollectionTransfer">
+        <property name="queues" type="RabbitMqQueue[]" strict="true"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Shared/RabbitMq/Transfer/rabbit_mq.transfer.xml
+++ b/src/Spryker/Shared/RabbitMq/Transfer/rabbit_mq.transfer.xml
@@ -93,8 +93,4 @@
         <property name="queueName" type="string"/>
     </transfer>
 
-    <transfer name="RabbitMqQueueCollectionTransfer">
-        <property name="queues" type="RabbitMqQueue[]" strict="true"/>
-    </transfer>
-
 </transfers>

--- a/src/Spryker/Shared/RabbitMq/Transfer/rabbit_mq.transfer.xml
+++ b/src/Spryker/Shared/RabbitMq/Transfer/rabbit_mq.transfer.xml
@@ -53,7 +53,6 @@
     </transfer>
 
     <transfer name="RabbitMqQueue">
-        <property name="messageCount" type="int" strict="true"/>
         <property name="name" type="string"/>
         <property name="virtualHost" type="string"/>
     </transfer>

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/Exchange.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/Exchange.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Exchange;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/ExchangeInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/ExchangeInfo.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Exchange;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/ExchangeInfoInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/ExchangeInfoInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Exchange;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/ExchangeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/ExchangeInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Exchange;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/Filter/ExchangeFilterByName.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/Filter/ExchangeFilterByName.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Exchange\Filter;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/Filter/ExchangeFilterInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Exchange/Filter/ExchangeFilterInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Exchange\Filter;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Permission/UserPermissionHandler.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Permission/UserPermissionHandler.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Permission;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Permission/UserPermissionHandlerInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Permission/UserPermissionHandlerInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Permission;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/Queue.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/Queue.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Queue;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -80,12 +80,25 @@ class QueueInfo implements QueueInfoInterface
         if ($response->getStatusCode() === 200) {
             $decodedResponse = json_decode($response->getBody()->getContents(), true);
 
-            foreach ($decodedResponse as $queueInfo) {
-                $rabbitMqQueueTransfer = (new RabbitMqQueueTransfer())->fromArray($queueInfo, true);
-                $rabbitMqQueueTransfer->setMessageCount($queueInfo['messages']);
+            return $this->addRabbitMqQueues($rabbitMqQueueCollectionTransfer, $decodedResponse);
+        }
 
-                $rabbitMqQueueCollectionTransfer->addRabbitMqQueue($rabbitMqQueueTransfer);
-            }
+        return $rabbitMqQueueCollectionTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer $rabbitMqQueueCollectionTransfer
+     * @param array $response
+     *
+     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     */
+    protected function addRabbitMqQueues(RabbitMqQueueCollectionTransfer $rabbitMqQueueCollectionTransfer, array $response)
+    {
+        foreach ($response as $queueInfo) {
+            $rabbitMqQueueTransfer = new RabbitMqQueueTransfer();
+            $rabbitMqQueueTransfer->setName($queueInfo['name']);
+
+            $rabbitMqQueueCollectionTransfer->addRabbitMqQueue($rabbitMqQueueTransfer);
         }
 
         return $rabbitMqQueueCollectionTransfer;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -91,6 +91,12 @@ class QueueInfo implements QueueInfoInterface
         return $rabbitMqQueueCollectionTransfer;
     }
 
+    /**
+     * @param string $currentQueueName
+     * @param array<string> $queueNames
+     *
+     * @return bool
+     */
     public function isApplicableQueue(string $currentQueueName, array $queueNames): bool
     {
         return in_array($currentQueueName, $queueNames);

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -56,7 +56,7 @@ class QueueInfo implements QueueInfoInterface
     {
         $response = $this->client->get($this->apiQueuesUrl, ['auth' => [$this->username, $this->password]]);
 
-        if ($response->getStatusCode() === 200) {
+        if ($response->getStatusCode() !== 200) {
             return true;
         }
 

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Queue;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -58,7 +58,12 @@ class QueueInfo implements QueueInfoInterface
         if ($response->getStatusCode() === 200) {
             $decodedResponse = json_decode($response->getBody()->getContents(), true);
 
-            return $this->addRabbitMqQueues($rabbitMqQueueCollectionTransfer, $decodedResponse);
+            foreach ($decodedResponse as $queueInfo) {
+                $rabbitMqQueueTransfer = (new RabbitMqQueueTransfer())->fromArray($queueInfo, true);
+                $rabbitMqQueueTransfer->setMessageCount($queueInfo['messages']);
+
+                $rabbitMqQueueCollectionTransfer->addRabbitMqQueue($rabbitMqQueueTransfer);
+            }
         }
 
         return $rabbitMqQueueCollectionTransfer;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -57,12 +57,14 @@ class QueueInfo implements QueueInfoInterface
         $response = $this->client->get($this->apiQueuesUrl, ['auth' => [$this->username, $this->password]]);
 
         if ($response->getStatusCode() === 200) {
-            $decodedResponse = json_decode($response->getBody()->getContents(), true);
+            return true;
+        }
 
-            foreach ($decodedResponse as $queueInfo) {
-                if ($queueInfo['messages'] > 0 && $this->isApplicableQueue($queueInfo['name'], $queueNames)) {
-                    return false;
-                }
+        $decodedResponse = json_decode($response->getBody()->getContents(), true);
+
+        foreach ($decodedResponse as $queueInfo) {
+            if ($queueInfo['messages'] > 0 && $this->isApplicableQueue($queueInfo['name'], $queueNames)) {
+                return false;
             }
         }
 

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -48,13 +48,14 @@ class QueueInfo implements QueueInfoInterface
     }
 
     /**
+     * @param array $queueNames
+     *
      * @return bool
      */
     public function areQueuesEmpty(array $queueNames): bool
     {
         $response = $this->client->get($this->apiQueuesUrl, ['auth' => [$this->username, $this->password]]);
 
-        $rabbitMqQueueCollectionTransfer = new RabbitMqQueueCollectionTransfer();
         if ($response->getStatusCode() === 200) {
             $decodedResponse = json_decode($response->getBody()->getContents(), true);
 

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfo.php
@@ -63,7 +63,7 @@ class QueueInfo implements QueueInfoInterface
         $decodedResponse = json_decode($response->getBody()->getContents(), true);
 
         foreach ($decodedResponse as $queueInfo) {
-            if ($queueInfo['messages'] > 0 && $this->isApplicableQueue($queueInfo['name'], $queueNames)) {
+            if ($queueInfo['messages'] > 0 && in_array($queueInfo['name'], $queueNames)) {
                 return false;
             }
         }
@@ -104,16 +104,5 @@ class QueueInfo implements QueueInfoInterface
         }
 
         return $rabbitMqQueueCollectionTransfer;
-    }
-
-    /**
-     * @param string $currentQueueName
-     * @param array<string> $queueNames
-     *
-     * @return bool
-     */
-    public function isApplicableQueue(string $currentQueueName, array $queueNames): bool
-    {
-        return in_array($currentQueueName, $queueNames);
     }
 }

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
@@ -10,11 +10,16 @@ namespace Spryker\Zed\RabbitMq\Business\Model\Queue;
 interface QueueInfoInterface
 {
     /**
+     * @param array<string> $queueNames
+     *
      * @return bool
      */
     public function areQueuesEmpty(array $queueNames): bool;
 
     /**
+     * @param string $currentQueueName
+     * @param array<string> $queueNames
+     *
      * @return bool
      */
     public function isApplicableQueue(string $currentQueueName, array $queueNames): bool;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
@@ -20,12 +20,4 @@ interface QueueInfoInterface
      * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
      */
     public function getQueues();
-
-    /**
-     * @param string $currentQueueName
-     * @param array<string> $queueNames
-     *
-     * @return bool
-     */
-    public function isApplicableQueue(string $currentQueueName, array $queueNames): bool;
 }

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Queue;

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
@@ -17,6 +17,11 @@ interface QueueInfoInterface
     public function areQueuesEmpty(array $queueNames): bool;
 
     /**
+     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     */
+    public function getQueues();
+
+    /**
      * @param string $currentQueueName
      * @param array<string> $queueNames
      *

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInfoInterface.php
@@ -10,7 +10,12 @@ namespace Spryker\Zed\RabbitMq\Business\Model\Queue;
 interface QueueInfoInterface
 {
     /**
-     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     * @return bool
      */
-    public function getQueues();
+    public function areQueuesEmpty(array $queueNames): bool;
+
+    /**
+     * @return bool
+     */
+    public function isApplicableQueue(string $currentQueueName, array $queueNames): bool;
 }

--- a/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/Model/Queue/QueueInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business\Model\Queue;

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business;

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -15,6 +15,7 @@ use Spryker\Zed\RabbitMq\Business\Model\Exchange\Filter\ExchangeFilterByName;
 use Spryker\Zed\RabbitMq\Business\Model\Permission\UserPermissionHandler;
 use Spryker\Zed\RabbitMq\Business\Model\Queue\Queue;
 use Spryker\Zed\RabbitMq\Business\Model\Queue\QueueInfo;
+use Spryker\Zed\RabbitMq\Business\Model\Queue\QueueInfoInterface;
 use Spryker\Zed\RabbitMq\RabbitMqDependencyProvider;
 
 /**

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -36,7 +36,7 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
     /**
      * @return \Spryker\Zed\RabbitMq\Business\Model\Queue\QueueInfoInterface
      */
-    public function createQueueInfo()
+    public function createQueueInfo(): QueueInfoInterface
     {
         return new QueueInfo(
             $this->getGuzzleClient(),

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -44,7 +44,6 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
             $this->getConfig()->getApiQueuesUrl(),
             $this->getConfig()->getApiUsername(),
             $this->getConfig()->getApiPassword(),
-            $this->getConection(),
         );
     }
 

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -44,7 +44,6 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
             $this->getConfig()->getApiQueuesUrl(),
             $this->getConfig()->getApiUsername(),
             $this->getConfig()->getApiPassword(),
-            $this->getQueueClient(),
         );
     }
 
@@ -58,14 +57,6 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
             $this->getQueueAdapter(),
             $this->createExchangeFilter(),
         );
-    }
-
-    /**
-     * @return \Spryker\Client\Queue\QueueClientInterface
-     */
-    public function getQueueClient()
-    {
-        return $this->getProvidedDependency(RabbitMqDependencyProvider::CLIENT_QUEUE);
     }
 
     /**

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -44,6 +44,7 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
             $this->getConfig()->getApiQueuesUrl(),
             $this->getConfig()->getApiUsername(),
             $this->getConfig()->getApiPassword(),
+            $this->getConection(),
         );
     }
 

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -44,6 +44,7 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
             $this->getConfig()->getApiQueuesUrl(),
             $this->getConfig()->getApiUsername(),
             $this->getConfig()->getApiPassword(),
+            $this->getQueueClient(),
         );
     }
 
@@ -57,6 +58,14 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
             $this->getQueueAdapter(),
             $this->createExchangeFilter(),
         );
+    }
+
+    /**
+     * @return \Spryker\Client\Queue\QueueClientInterface
+     */
+    public function getQueueClient()
+    {
+        return $this->getProvidedDependency(RabbitMqDependencyProvider::CLIENT_QUEUE);
     }
 
     /**

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqBusinessFactory.php
@@ -36,7 +36,7 @@ class RabbitMqBusinessFactory extends AbstractBusinessFactory
     /**
      * @return \Spryker\Zed\RabbitMq\Business\Model\Queue\QueueInfoInterface
      */
-    protected function createQueueInfo()
+    public function createQueueInfo()
     {
         return new QueueInfo(
             $this->getGuzzleClient(),

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -82,4 +82,12 @@ class RabbitMqFacade extends AbstractFacade implements RabbitMqFacadeInterface
     {
         return $this->getFactory()->createUserPermissionHandler()->setPermissions($logger);
     }
+
+    /**
+    * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+    */
+    public function getQueues(): RabbitMqQueueCollectionTransfer
+    {
+        return $this->getFactory()->createQueueInfo()->getQueues();
+    }
 }

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business;

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -7,9 +7,9 @@
 
 namespace Spryker\Zed\RabbitMq\Business;
 
+use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Psr\Log\LoggerInterface;
 use Spryker\Zed\Kernel\Business\AbstractFacade;
-use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 
 /**
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqBusinessFactory getFactory()
@@ -85,8 +85,12 @@ class RabbitMqFacade extends AbstractFacade implements RabbitMqFacadeInterface
     }
 
     /**
-    * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
-    */
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     */
     public function getQueues(): RabbitMqQueueCollectionTransfer
     {
         return $this->getFactory()->createQueueInfo()->getQueues();

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -9,6 +9,7 @@ namespace Spryker\Zed\RabbitMq\Business;
 
 use Psr\Log\LoggerInterface;
 use Spryker\Zed\Kernel\Business\AbstractFacade;
+use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 
 /**
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqBusinessFactory getFactory()

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -85,14 +85,12 @@ class RabbitMqFacade extends AbstractFacade implements RabbitMqFacadeInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
      * @api
      *
-     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     * @return bool
      */
-    public function getQueues(): RabbitMqQueueCollectionTransfer
+    public function areQueuesEmpty($queueNames): bool
     {
-        return $this->getFactory()->createQueueInfo()->getQueues();
+        return $this->getFactory()->createQueueInfo()->areQueuesEmpty($queueNames);
     }
 }

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -92,7 +92,7 @@ class RabbitMqFacade extends AbstractFacade implements RabbitMqFacadeInterface
      *
      * @return bool
      */
-    public function areQueuesEmpty($queueNames): bool
+    public function areQueuesEmpty(array $queueNames): bool
     {
         return $this->getFactory()->createQueueInfo()->areQueuesEmpty($queueNames);
     }

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -7,7 +7,6 @@
 
 namespace Spryker\Zed\RabbitMq\Business;
 
-use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Psr\Log\LoggerInterface;
 use Spryker\Zed\Kernel\Business\AbstractFacade;
 
@@ -85,6 +84,8 @@ class RabbitMqFacade extends AbstractFacade implements RabbitMqFacadeInterface
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return bool

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacade.php
@@ -88,6 +88,8 @@ class RabbitMqFacade extends AbstractFacade implements RabbitMqFacadeInterface
      *
      * @api
      *
+     * @param array<string> $queueNames
+     *
      * @return bool
      */
     public function areQueuesEmpty($queueNames): bool

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Business;

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -73,7 +73,12 @@ interface RabbitMqFacadeInterface
     public function setUserPermissions(LoggerInterface $logger);
 
     /**
+     * Specification:
+     *  - Checks if any of the applicable queues have messages.
+     *
      * @api
+     *
+     * @param array<string> $queueNames
      *
      * @return bool
      */

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -7,8 +7,8 @@
 
 namespace Spryker\Zed\RabbitMq\Business;
 
-use Psr\Log\LoggerInterface;
 use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
+use Psr\Log\LoggerInterface;
 
 /**
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqBusinessFactory getFactory()

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -8,6 +8,7 @@
 namespace Spryker\Zed\RabbitMq\Business;
 
 use Psr\Log\LoggerInterface;
+use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 
 /**
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqBusinessFactory getFactory()

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -76,7 +76,7 @@ interface RabbitMqFacadeInterface
     /**
      * @api
      *
-     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     * @return bool
      */
-    public function getQueues(): RabbitMqQueueCollectionTransfer;
+    public function areQueuesEmpty($queueNames): bool;
 }

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -82,5 +82,5 @@ interface RabbitMqFacadeInterface
      *
      * @return bool
      */
-    public function areQueuesEmpty($queueNames): bool;
+    public function areQueuesEmpty(array $queueNames): bool;
 }

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -7,7 +7,6 @@
 
 namespace Spryker\Zed\RabbitMq\Business;
 
-use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Business/RabbitMqFacadeInterface.php
@@ -71,4 +71,11 @@ interface RabbitMqFacadeInterface
      * @return bool
      */
     public function setUserPermissions(LoggerInterface $logger);
+
+    /**
+     * @api
+     *
+     * @return \Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer
+     */
+    public function getQueues(): RabbitMqQueueCollectionTransfer;
 }

--- a/src/Spryker/Zed/RabbitMq/Communication/Console/DeleteAllExchangesConsole.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Console/DeleteAllExchangesConsole.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Communication\Console;

--- a/src/Spryker/Zed/RabbitMq/Communication/Console/DeleteAllQueuesConsole.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Console/DeleteAllQueuesConsole.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Communication\Console;

--- a/src/Spryker/Zed/RabbitMq/Communication/Console/PurgeAllQueuesConsole.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Console/PurgeAllQueuesConsole.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Communication\Console;

--- a/src/Spryker/Zed/RabbitMq/Communication/Console/QueueSetupConsole.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Console/QueueSetupConsole.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Communication\Console;

--- a/src/Spryker/Zed/RabbitMq/Communication/Console/SetUserPermissionsConsole.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Console/SetUserPermissionsConsole.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Communication\Console;

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Communication\Plugin\Queue;

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
@@ -19,7 +19,6 @@ class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueM
 {
     /**
      * {@inheritDoc}
-     *
      * - Checks if any of the queues provided have messages in them.
      *
      * @api

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
@@ -5,7 +5,7 @@
  * For full license information, please view the LICENSE file that was distributed with this source code.
  */
 
-namespace Spryker\Zed\RabbitMq\Communication\Plugin;
+namespace Spryker\Zed\RabbitMq\Communication\Plugin\Queue;
 
 use Spryker\Client\RabbitMq\Model\RabbitMqAdapter;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
@@ -20,7 +20,7 @@ class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueM
     /**
      * {@inheritDoc}
      *
-     * - Checks if any of the queues provided has messages in it.
+     * - Checks if any of the queues provided have messages in them.
      *
      * @api
      *

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/Queue/RabbitMqQueueMessageCheckerPlugin.php
@@ -35,7 +35,6 @@ class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueM
 
     /**
      * {@inheritDoc}
-     *
      * - Checks if the current queue adapter is RabbitMq.
      *
      * @api

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -14,6 +14,8 @@ use Spryker\Zed\QueueExtension\Dependency\Plugin\QueueMessageCheckerPluginInterf
 /**
  * {@inheritDoc}
  *
+ * - Checks if any of the queues provided has messages in it.
+ *
  * @api
  *
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqFacadeInterface getFacade()

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -7,7 +7,6 @@
 
 namespace Spryker\Zed\RabbitMq\Communication\Plugin;
 
-use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\Queue\Dependency\Plugin\QueueMessageCheckerPluginInterface;
 

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -7,8 +7,9 @@
 
 namespace Spryker\Zed\RabbitMq\Communication\Plugin;
 
+use Spryker\Client\RabbitMq\Model\RabbitMqAdapter;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
-use Spryker\Zed\Queue\Dependency\Plugin\QueueMessageCheckerPluginInterface;
+use Spryker\Zed\QueueExtension\Dependency\Plugin\QueueMessageCheckerPluginInterface;
 
 /**
  * {@inheritDoc}
@@ -32,5 +33,19 @@ class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueM
     public function areQueuesEmpty(array $queueNames): bool
     {
         return $this->getFacade()->areQueuesEmpty($queueNames);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param string $adapterName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $adapterName): bool
+    {
+        return $adapterName === RabbitMqAdapter::class;
     }
 }

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -9,7 +9,7 @@ namespace Spryker\Zed\RabbitMq\Communication\Plugin;
 
 use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
-use Spryker\Zed\Queue\Dependency\Plugin\QueueProviderPluginInterface;
+use Spryker\Zed\Queue\Dependency\Plugin\QueueMessageCheckerPluginInterface;
 
 /**
  * {@inheritDoc}
@@ -19,10 +19,10 @@ use Spryker\Zed\Queue\Dependency\Plugin\QueueProviderPluginInterface;
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqFacadeInterface getFacade()
  * @method \Spryker\Zed\RabbitMq\RabbitMqConfig getConfig()
  */
-class RabbitMqQueueProviderPlugin extends AbstractPlugin implements QueueProviderPluginInterface
+class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueMessageCheckerPluginInterface
 {
-    public function getQueues(): RabbitMqQueueCollectionTransfer
+    public function areQueuesEmpty(array $queueNames): bool
     {
-        return $this->getFacade()->getQueues();
+        return $this->getFacade()->areQueuesEmpty($queueNames);
     }
 }

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -14,8 +14,6 @@ use Spryker\Zed\QueueExtension\Dependency\Plugin\QueueMessageCheckerPluginInterf
 /**
  * {@inheritDoc}
  *
- * - Checks if any of the queues provided has messages in it.
- *
  * @api
  *
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqFacadeInterface getFacade()
@@ -25,6 +23,8 @@ class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueM
 {
     /**
      * {@inheritDoc}
+     *
+     * - Checks if any of the queues provided has messages in it.
      *
      * @api
      *
@@ -39,6 +39,8 @@ class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueM
 
     /**
      * {@inheritDoc}
+     *
+     * - Checks if the current queue adapter is RabbitMq.
      *
      * @api
      *

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -12,8 +12,6 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\QueueExtension\Dependency\Plugin\QueueMessageCheckerPluginInterface;
 
 /**
- * @api
- *
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqFacadeInterface getFacade()
  * @method \Spryker\Zed\RabbitMq\RabbitMqConfig getConfig()
  */

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -12,8 +12,6 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\QueueExtension\Dependency\Plugin\QueueMessageCheckerPluginInterface;
 
 /**
- * {@inheritDoc}
- *
  * @api
  *
  * @method \Spryker\Zed\RabbitMq\Business\RabbitMqFacadeInterface getFacade()

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueMessageCheckerPlugin.php
@@ -20,6 +20,15 @@ use Spryker\Zed\Queue\Dependency\Plugin\QueueMessageCheckerPluginInterface;
  */
 class RabbitMqQueueMessageCheckerPlugin extends AbstractPlugin implements QueueMessageCheckerPluginInterface
 {
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param array<string> $queueNames
+     *
+     * @return bool
+     */
     public function areQueuesEmpty(array $queueNames): bool
     {
         return $this->getFacade()->areQueuesEmpty($queueNames);

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueProviderPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueProviderPlugin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spryker\Zed\RabbitMq\Communication\Plugin;
+
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use Spryker\Zed\Queue\Dependency\Plugin\QueueProviderPluginInterface;
+use Generated\Shared\Transfer\QueueCollectionTransfer;
+
+/**
+ * @method \Spryker\Zed\[module]\Business\[module]Facade getFacade()
+ */
+class RabbitMqQueueProviderPlugin extends AbstractPlugin implements QueueProviderPluginInterface
+{
+    public function getQueues(): QueueCollectionTransfer
+    {
+        return $this->getFacade()->getQueues();
+    }
+}

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueProviderPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueProviderPlugin.php
@@ -1,14 +1,23 @@
 <?php
 
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
 namespace Spryker\Zed\RabbitMq\Communication\Plugin;
 
 use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\Queue\Dependency\Plugin\QueueProviderPluginInterface;
-use Generated\Shared\Transfer\QueueCollectionTransfer;
 
 /**
- * @method \Spryker\Zed\[module]\Business\[module]Facade getFacade()
+ * {@inheritDoc}
+ *
+ * @api
+ *
+ * @method \Spryker\Zed\RabbitMq\Business\RabbitMqFacadeInterface getFacade()
+ * @method \Spryker\Zed\RabbitMq\RabbitMqConfig getConfig()
  */
 class RabbitMqQueueProviderPlugin extends AbstractPlugin implements QueueProviderPluginInterface
 {

--- a/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueProviderPlugin.php
+++ b/src/Spryker/Zed/RabbitMq/Communication/Plugin/RabbitMqQueueProviderPlugin.php
@@ -2,6 +2,7 @@
 
 namespace Spryker\Zed\RabbitMq\Communication\Plugin;
 
+use Generated\Shared\Transfer\RabbitMqQueueCollectionTransfer;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\Queue\Dependency\Plugin\QueueProviderPluginInterface;
 use Generated\Shared\Transfer\QueueCollectionTransfer;
@@ -11,7 +12,7 @@ use Generated\Shared\Transfer\QueueCollectionTransfer;
  */
 class RabbitMqQueueProviderPlugin extends AbstractPlugin implements QueueProviderPluginInterface
 {
-    public function getQueues(): QueueCollectionTransfer
+    public function getQueues(): RabbitMqQueueCollectionTransfer
     {
         return $this->getFacade()->getQueues();
     }

--- a/src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleBridge.php
+++ b/src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleBridge.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Dependency\Guzzle;

--- a/src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleInterface.php
+++ b/src/Spryker/Zed/RabbitMq/Dependency/Guzzle/RabbitMqToGuzzleInterface.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq\Dependency\Guzzle;

--- a/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqConfig.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq;

--- a/src/Spryker/Zed/RabbitMq/RabbitMqDependencyProvider.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqDependencyProvider.php
@@ -21,11 +21,6 @@ class RabbitMqDependencyProvider extends AbstractBundleDependencyProvider
     /**
      * @var string
      */
-    public const CLIENT_QUEUE = 'CLIENT_QUEUE';
-
-    /**
-     * @var string
-     */
     public const QUEUE_ADAPTER = 'QUEUE_ADAPTER';
 
     /**
@@ -46,7 +41,6 @@ class RabbitMqDependencyProvider extends AbstractBundleDependencyProvider
     public function provideBusinessLayerDependencies(Container $container)
     {
         $container = $this->addQueueAdapter($container);
-        $container = $this->addQueueClient($container);
         $container = $this->addGuzzleClient($container);
         $container = $this->addConnection($container);
 
@@ -62,20 +56,6 @@ class RabbitMqDependencyProvider extends AbstractBundleDependencyProvider
     {
         $container->set(static::QUEUE_ADAPTER, function () use ($container) {
             return $container->getLocator()->rabbitMq()->client()->createQueueAdapter();
-        });
-
-        return $container;
-    }
-
-    /**
-     * @param \Spryker\Zed\Kernel\Container $container
-     *
-     * @return \Spryker\Zed\Kernel\Container
-     */
-    protected function addQueueClient(Container $container)
-    {
-        $container->set(static::CLIENT_QUEUE, function () use ($container) {
-            return $container->getLocator()->queue()->client();
         });
 
         return $container;

--- a/src/Spryker/Zed/RabbitMq/RabbitMqDependencyProvider.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqDependencyProvider.php
@@ -21,6 +21,11 @@ class RabbitMqDependencyProvider extends AbstractBundleDependencyProvider
     /**
      * @var string
      */
+    public const CLIENT_QUEUE = 'CLIENT_QUEUE';
+
+    /**
+     * @var string
+     */
     public const QUEUE_ADAPTER = 'QUEUE_ADAPTER';
 
     /**
@@ -41,6 +46,7 @@ class RabbitMqDependencyProvider extends AbstractBundleDependencyProvider
     public function provideBusinessLayerDependencies(Container $container)
     {
         $container = $this->addQueueAdapter($container);
+        $container = $this->addQueueClient($container);
         $container = $this->addGuzzleClient($container);
         $container = $this->addConnection($container);
 
@@ -56,6 +62,20 @@ class RabbitMqDependencyProvider extends AbstractBundleDependencyProvider
     {
         $container->set(static::QUEUE_ADAPTER, function () use ($container) {
             return $container->getLocator()->rabbitMq()->client()->createQueueAdapter();
+        });
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addQueueClient(Container $container)
+    {
+        $container->set(static::CLIENT_QUEUE, function () use ($container) {
+            return $container->getLocator()->queue()->client();
         });
 
         return $container;

--- a/src/Spryker/Zed/RabbitMq/RabbitMqDependencyProvider.php
+++ b/src/Spryker/Zed/RabbitMq/RabbitMqDependencyProvider.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace Spryker\Zed\RabbitMq;

--- a/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
+++ b/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionBuilder/ConnectionBuilderTest.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace SprykerTest\Client\RabbitMq\Model\Connection\ConnectionBuilder;

--- a/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionManagerTest.php
+++ b/tests/SprykerTest/Client/RabbitMq/Model/Connection/ConnectionManagerTest.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace SprykerTest\Client\RabbitMq\Model\Connection;

--- a/tests/SprykerTest/Client/RabbitMq/_support/Helper/RabbitMqHelper.php
+++ b/tests/SprykerTest/Client/RabbitMq/_support/Helper/RabbitMqHelper.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace SprykerTest\Client\RabbitMq\Helper;

--- a/tests/SprykerTest/Client/RabbitMq/_support/RabbitMqClientTester.php
+++ b/tests/SprykerTest/Client/RabbitMq/_support/RabbitMqClientTester.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace SprykerTest\Client\RabbitMq;

--- a/tests/SprykerTest/Zed/RabbitMq/Business/Model/Exchange/Filter/ExchangeFilterByNameTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/Model/Exchange/Filter/ExchangeFilterByNameTest.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace SprykerTest\Zed\Business\Model\Exchange\Filter;

--- a/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
@@ -39,6 +39,7 @@ class RabbitMqFacadeTest extends Unit
      * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\RabbitMq\Business\Queue\QueueInfo
      */
     protected $queueInfoMock;
+
     /**
      * @var array<string>
      */
@@ -61,6 +62,7 @@ class RabbitMqFacadeTest extends Unit
      */
     public function testAreQueuesEmptyReturnsTrueForEmptyQueues(): void
     {
+        // Arrange
         $expectedResult = true;
 
         $this->rabbitMqBusinessFactoryMock
@@ -72,8 +74,10 @@ class RabbitMqFacadeTest extends Unit
             ->with($this->queueNames)
             ->willReturn($expectedResult);
 
+        // Act
         $result = $this->rabbitMqFacade->areQueuesEmpty($this->queueNames);
 
+        // Assert
         $this->assertEquals($expectedResult, $result);
     }
 
@@ -82,6 +86,7 @@ class RabbitMqFacadeTest extends Unit
      */
     public function testAreQueuesEmptyReturnsFalseForNonEmptyQueues(): void
     {
+        // Arrange
         $expectedResult = false;
 
         $this->rabbitMqBusinessFactoryMock
@@ -93,8 +98,10 @@ class RabbitMqFacadeTest extends Unit
             ->with($this->queueNames)
             ->willReturn($expectedResult);
 
+        // Act
         $result = $this->rabbitMqFacade->areQueuesEmpty($this->queueNames);
 
+        // Assert
         $this->assertEquals($expectedResult, $result);
     }
 }

--- a/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
@@ -84,8 +84,6 @@ class RabbitMqFacadeTest extends Unit
             $queueClient->purgeQueue($queueName);
         }
 
-        sleep(10);
-
         // Assert
         $this->assertTrue($this->tester->getLocator()->rabbitMq()->facade()->areQueuesEmpty(static::QUEUE_NAMES));
     }
@@ -108,8 +106,6 @@ class RabbitMqFacadeTest extends Unit
         foreach (static::QUEUE_NAMES as $queueName) {
             $queueClient->sendMessages($queueName, $messagesToSend);
         }
-
-        sleep(10);
 
         // Assert
         $this->assertFalse($this->tester->getLocator()->rabbitMq()->facade()->areQueuesEmpty(static::QUEUE_NAMES));

--- a/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
@@ -36,7 +36,7 @@ class RabbitMqFacadeTest extends Unit
     protected $rabbitMqBusinessFactoryMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\RabbitMq\Business\Queue\QueueInfo
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\RabbitMq\Business\Model\Queue\QueueInfo
      */
     protected $queueInfoMock;
 

--- a/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
@@ -84,7 +84,7 @@ class RabbitMqFacadeTest extends Unit
             $queueClient->purgeQueue($queueName);
         }
 
-        sleep(7);
+        sleep(10);
 
         // Assert
         $this->assertTrue($this->tester->getLocator()->rabbitMq()->facade()->areQueuesEmpty(static::QUEUE_NAMES));
@@ -109,7 +109,7 @@ class RabbitMqFacadeTest extends Unit
             $queueClient->sendMessages($queueName, $messagesToSend);
         }
 
-        sleep(7);
+        sleep(10);
 
         // Assert
         $this->assertFalse($this->tester->getLocator()->rabbitMq()->facade()->areQueuesEmpty(static::QUEUE_NAMES));

--- a/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
@@ -60,7 +60,7 @@ class RabbitMqFacadeTest extends Unit
     /**
      * @return void
      */
-    protected function _before()
+    protected function _before(): void
     {
         $this->tester->setDependency(SprykerQueueDependencyProvider::QUEUE_ADAPTERS, function (Container $container) {
             return [
@@ -74,7 +74,7 @@ class RabbitMqFacadeTest extends Unit
     /**
      * @return void
      */
-    public function testAreQueuesEmptyReturnsTrueForEmptyQueues()
+    public function testAreQueuesEmptyReturnsTrueForEmptyQueues(): void
     {
         // Arrange
         $queueClient = $this->tester->getLocator()->queue()->client();
@@ -93,7 +93,7 @@ class RabbitMqFacadeTest extends Unit
     /**
      * @return void
      */
-    public function testAreQueuesEmptyReturnsFalseForNonEmptyQueues()
+    public function testAreQueuesEmptyReturnsFalseForNonEmptyQueues(): void
     {
         // Arrange
         $queueClient = $this->tester->getLocator()->queue()->client();

--- a/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
+++ b/tests/SprykerTest/Zed/RabbitMq/Business/RabbitMqFacadeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Zed\RabbitMq\Business;
+
+use Codeception\Test\Unit;
+use Spryker\Zed\RabbitMq\Business\Model\Queue\QueueInfo;
+use Spryker\Zed\RabbitMq\Business\RabbitMqBusinessFactory;
+use Spryker\Zed\RabbitMq\Business\RabbitMqFacade;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Zed
+ * @group RabbitMq
+ * @group Business
+ * @group Facade
+ * @group RabbitMqFacadeTest
+ * Add your own group annotations below this line
+ */
+class RabbitMqFacadeTest extends Unit
+{
+    /**
+     * @var \Spryker\Zed\RabbitMq\Business\RabbitMqFacade
+     */
+    protected $rabbitMqFacade;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\RabbitMq\Business\RabbitMqBusinessFactory
+     */
+    protected $rabbitMqBusinessFactoryMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\RabbitMq\Business\Queue\QueueInfo
+     */
+    protected $queueInfoMock;
+
+    /**
+     * @return void
+     */
+    protected function _before()
+    {
+        $this->rabbitMqBusinessFactoryMock = $this->createMock(RabbitMqBusinessFactory::class);
+        $this->queueInfoMock = $this->createMock(QueueInfo::class);
+
+        $this->rabbitMqFacade = new RabbitMqFacade();
+        $this->rabbitMqFacade->setFactory($this->rabbitMqBusinessFactoryMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAreQueuesEmpty()
+    {
+        $queueNames = ['queue1', 'queue2'];
+        $expectedResult = true;
+
+        $this->rabbitMqBusinessFactoryMock
+            ->method('createQueueInfo')
+            ->willReturn($this->queueInfoMock);
+
+        $this->queueInfoMock
+            ->method('areQueuesEmpty')
+            ->with($queueNames)
+            ->willReturn($expectedResult);
+
+        $result = $this->rabbitMqFacade->areQueuesEmpty($queueNames);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
+++ b/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
@@ -8,6 +8,8 @@
 namespace SprykerTest\Zed\RabbitMq;
 
 use Codeception\Actor;
+use Generated\Shared\Transfer\QueueSendMessageTransfer;
+use Spryker\Zed\Event\Communication\Plugin\Queue\EventQueueMessageProcessorPlugin;
 
 /**
  * Inherited Methods
@@ -29,7 +31,43 @@ class RabbitMqBusinessTester extends Actor
 {
     use _generated\RabbitMqBusinessTesterActions;
 
-   /**
-    * Define custom actions here
-    */
+    /**
+     * @var string
+     */
+    protected const STORE_NAME_DE = 'DE';
+
+    /**
+     * @param array<string> $queueNames
+     *
+     * @return array<\Spryker\Zed\Queue\Dependency\Plugin\QueueMessageProcessorPluginInterface>
+     */
+    public function getMessageProcessorPlugins(array $queueNames): array
+    {
+        $plugins = [];
+
+        foreach ($queueNames as $queueName) {
+            $plugins[$queueName] = new EventQueueMessageProcessorPlugin();
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\QueueSendMessageTransfer
+     */
+    public function buildSendMessageTransfer(): QueueSendMessageTransfer
+    {
+        $queueSendTransfer = new QueueSendMessageTransfer();
+        $queueSendTransfer->setBody(json_encode([
+            'write' => [
+                'key' => 'testKey',
+                'value' => 'testValue',
+                'resource' => 'testResource',
+                'params' => [],
+            ],
+        ]));
+        $queueSendTransfer->setStoreName(static::STORE_NAME_DE);
+
+        return $queueSendTransfer;
+    }
 }

--- a/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
+++ b/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
@@ -57,8 +57,8 @@ class RabbitMqBusinessTester extends Actor
      */
     public function buildSendMessageTransfer(): QueueSendMessageTransfer
     {
-        $queueSendTransfer = new QueueSendMessageTransfer();
-        $queueSendTransfer->setBody(json_encode([
+        $queueSendMessageTransfer = new QueueSendMessageTransfer();
+        $queueSendMessageTransfer->setBody(json_encode([
             'write' => [
                 'key' => 'testKey',
                 'value' => 'testValue',
@@ -66,8 +66,8 @@ class RabbitMqBusinessTester extends Actor
                 'params' => [],
             ],
         ]));
-        $queueSendTransfer->setStoreName(static::STORE_NAME_DE);
+        $queueSendMessageTransfer->setStoreName(static::STORE_NAME_DE);
 
-        return $queueSendTransfer;
+        return $queueSendMessageTransfer;
     }
 }

--- a/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
+++ b/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
@@ -8,8 +8,6 @@
 namespace SprykerTest\Zed\RabbitMq;
 
 use Codeception\Actor;
-use Generated\Shared\Transfer\QueueSendMessageTransfer;
-use Spryker\Zed\Event\Communication\Plugin\Queue\EventQueueMessageProcessorPlugin;
 
 /**
  * Inherited Methods
@@ -31,4 +29,7 @@ class RabbitMqBusinessTester extends Actor
 {
     use _generated\RabbitMqBusinessTesterActions;
 
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
+++ b/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
@@ -31,43 +31,4 @@ class RabbitMqBusinessTester extends Actor
 {
     use _generated\RabbitMqBusinessTesterActions;
 
-    /**
-     * @var string
-     */
-    protected const STORE_NAME_DE = 'DE';
-
-    /**
-     * @param array<string> $queueNames
-     *
-     * @return array<\Spryker\Zed\Queue\Dependency\Plugin\QueueMessageProcessorPluginInterface>
-     */
-    public function getMessageProcessorPlugins(array $queueNames): array
-    {
-        $plugins = [];
-
-        foreach ($queueNames as $queueName) {
-            $plugins[$queueName] = new EventQueueMessageProcessorPlugin();
-        }
-
-        return $plugins;
-    }
-
-    /**
-     * @return \Generated\Shared\Transfer\QueueSendMessageTransfer
-     */
-    public function buildSendMessageTransfer(): QueueSendMessageTransfer
-    {
-        $queueSendMessageTransfer = new QueueSendMessageTransfer();
-        $queueSendMessageTransfer->setBody(json_encode([
-            'write' => [
-                'key' => 'testKey',
-                'value' => 'testValue',
-                'resource' => 'testResource',
-                'params' => [],
-            ],
-        ]));
-        $queueSendMessageTransfer->setStoreName(static::STORE_NAME_DE);
-
-        return $queueSendMessageTransfer;
-    }
 }

--- a/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
+++ b/tests/SprykerTest/Zed/RabbitMq/_support/RabbitMqBusinessTester.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * MIT License
- * For full license information, please view the LICENSE file that was distributed with this source code.
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
 namespace SprykerTest\Zed\RabbitMq;

--- a/tests/SprykerTest/Zed/RabbitMq/codeception.yml
+++ b/tests/SprykerTest/Zed/RabbitMq/codeception.yml
@@ -17,7 +17,6 @@ suites:
         modules:
             enabled:
                 - Asserts
-                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
                 - \SprykerTest\Shared\Testify\Helper\Environment
                 - \SprykerTest\Shared\Testify\Helper\ConfigHelper
                 - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
@@ -26,5 +25,4 @@ suites:
                 - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:
                       isolated: true
                 - \SprykerTest\Shared\Testify\Helper\DependencyHelper
-                - \SprykerTest\Zed\Testify\Helper\BusinessHelper
                 - \SprykerTest\Shared\Propel\Helper\ConnectionHelper

--- a/tests/SprykerTest/Zed/RabbitMq/codeception.yml
+++ b/tests/SprykerTest/Zed/RabbitMq/codeception.yml
@@ -16,10 +16,15 @@ suites:
         actor: RabbitMqBusinessTester
         modules:
             enabled:
-                - \SprykerTest\Shared\Testify\Helper\Environment:
-                      isolated: true
+                - Asserts
+                - \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
+                - \SprykerTest\Shared\Testify\Helper\Environment
                 - \SprykerTest\Shared\Testify\Helper\ConfigHelper
-                - \SprykerTest\Shared\Testify\Helper\LocatorHelper
+                - \SprykerTest\Shared\Testify\Helper\LocatorHelper:
+                      projectNamespaces: ['Pyz', 'Spryker']
                 - \SprykerTest\Shared\Testify\Helper\VirtualFilesystemHelper
                 - \SprykerTest\Shared\Transfer\Helper\TransferGenerateHelper:
                       isolated: true
+                - \SprykerTest\Shared\Testify\Helper\DependencyHelper
+                - \SprykerTest\Zed\Testify\Helper\BusinessHelper
+                - \SprykerTest\Shared\Propel\Helper\ConnectionHelper


### PR DESCRIPTION
- Developer(s): @aleksandr-velikanov

- Ticket: https://spryker.atlassian.net/browse/FRW-1877

- Release Group: https://release.spryker.com/release-groups/view/5484

- PR Overview: https://release.spryker.com/release/pull-request/11047

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   RabbitMq                 | minor                 |                       |

-----------------------------------------

#### Module RabbitMq

##### Change log

Improvements

- Introduced `RabbitMqQueueMessageCheckerPlugin` to check if there are messages in queues for RabbitMQ.
- Introduced `RabbitMqFacade::areQueuesEmpty()` to go through queues and see if at least one has messages.

