### PR TITLE
CC-38347: Check if connection already closed

### DIFF
--- a/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
+++ b/src/Spryker/Client/RabbitMq/Model/Connection/Connection.php
@@ -10,6 +10,7 @@ namespace Spryker\Client\RabbitMq\Model\Connection;
 use Generated\Shared\Transfer\QueueConnectionTransfer;
 use Generated\Shared\Transfer\RabbitMqOptionTransfer;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use Spryker\Client\RabbitMq\Model\Helper\QueueEstablishmentHelperInterface;
 use Spryker\Client\RabbitMq\RabbitMqConfig;
@@ -169,9 +170,8 @@ class Connection implements ConnectionInterface
     {
         try {
             $this->close();
-        } catch (AMQPProtocolChannelException $e) {
-            // Exchange was likely deleted previously
-            return;
+        } catch (AMQPProtocolChannelException | AMQPConnectionClosedException) {
+            // Exchange was likely deleted previously, or connection was already closed
         }
     }
 }


### PR DESCRIPTION
## PR Description
Add a meaningful description here that will let us know what you want to fix with this PR or what functionality you want to add.

Task: https://spryker.atlassian.net/browse/CC-38347

###### Change log
#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------- | :------------------------- |
   RabbitMq | minor |  |

#### Module RabbitMq

##### Change log

Improvements

- Adjusted `Connection::__destruct()` to skip AMQPConnectionClosedException if the connection is already closed.  
